### PR TITLE
feat: return OIDCProvider ARN

### DIFF
--- a/oidc-provider.yaml
+++ b/oidc-provider.yaml
@@ -138,3 +138,6 @@ Outputs:
   ClusterOIDCURL:
     Description: The OpenID Connect URL (without protocol)
     Value: !Ref ClusterOIDCURL
+  ClusterOIDCProvider:
+    Description: The ARN of the OIDCProvider
+    Value: !Ref ClusterOIDCProvider


### PR DESCRIPTION
Return the OIDCProvider ARN from this stack. It was already being returned by the lambda function.
Tested on our own infrastructure.