### PR TITLE
doc: provide programmatic license information

### DIFF
--- a/oidc-provider.yaml
+++ b/oidc-provider.yaml
@@ -1,6 +1,10 @@
 ---
+# SPDX-FileCopyrightText: 2020 Bamboo Loans
+# SPDX-License-Identifier: MIT
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'An example CloudFormation template to configure an EKS cluster with an OpenID Connect provider to use IAM backed service accounts'
+Metadata:
+  Source: https://github.com/bambooengineering/example-eks-oidc-iam-cloudformation
 
 Parameters:
   EKSClusterName:


### PR DESCRIPTION
Add programmatic license information to the file. Based on common practices found on GitHub and the advice by the REUSE project https://reuse.software/tutorial/